### PR TITLE
Add support for Nix with a flake, package, overlay and a Home-Manager module.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Nix related
+result/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 # Nix related
-result/
+result

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ Inspired from [rofi-wifi-menu](https://github.com/zbaylin/rofi-wifi-menu).
 - [Config](#config)
 - [Languages](#language-localization)
 - [Download-Usage](#download-usage)
-- [Instalationn](#installing-uninstalling-and-updating-ronema)
+- [Installation](#installing-uninstalling-and-updating-ronema)
 - [Themes](#themes)
 - [Examples-Usage](#examples-usage)
-- [ToDo](#todo)
+- [To-Do](#to-do)
 
 ### Requirements
 
@@ -24,24 +24,24 @@ Inspired from [rofi-wifi-menu](https://github.com/zbaylin/rofi-wifi-menu).
   - [dunst](https://github.com/dunst-project/dunst)
   - [fnott](https://codeberg.org/dnkl/fnott)
 - **nm-connection-editor** (_Optional_) (_For editing connections_)
-- [**qrencode**](https://fukuchi.org/works/qrencode) (_Optional_) (_For sharing wifi with qrcode_)
+- [**qrencode**](https://fukuchi.org/works/qrencode) (_Optional_) (_For sharing Wi-Fi with qr code_)
 
 ### Features
 
 - Connect to an existing network.
 - Disconnect from the network.
-- Turn on/off wifi.
-- Support for Multiple wifi devices.
-  - Option to change between wifi devices when available.
+- Turn on/off Wi-Fi.
+- Support for Multiple Wi-Fi devices.
+  - Option to change between Wi-Fi devices when available.
 - Manual Connection to a Access Point or a hidden one.
-- Turn on/off ethernet.
-  - See when ethernet is unavailable.
+- Turn on/off Ethernet.
+  - See when Ethernet is unavailable.
 - Restart the network.
 - Status
   - See devices Connection name and local IP.
-- See Current wifi password and share it with a qrcode.
+- See Current Wi-Fi password and share it with a qr code.
 - Connect to pre-configured VPNs.
-- Change the defualt signal strength bars with anything you want.
+- Change the default signal strength bars with anything you want.
 - Support for language localization based on configuration file.
 
 ### Screenshots
@@ -57,7 +57,7 @@ Inspired from [rofi-wifi-menu](https://github.com/zbaylin/rofi-wifi-menu).
 
 ```
 # Location
-# +---------- +
+# +-----------+
 # | 1 | 2 | 3 |
 # | 8 | 0 | 4 |
 # | 7 | 6 | 5 |
@@ -106,9 +106,256 @@ THEME="ronema.rasi"
 ```
 </details>
 
+<details>
+  <summary>Configuring with Nix</summary>
+
+  All of the above configuration fields are accessible directly in the Home-Manager module, like so:
+  ```nix
+  { lib, ... }:
+
+  {
+    programs.ronema = {
+      enable = true;
+
+      theme = {}; # Define a theme the same way you do it for Rofi. See https://nix-community.github.io/home-manager/options.xhtml#opt-programs.rofi.theme
+
+      languages = ./languages; # A directory containing the languages you want to add. This directory should contain at least the language used in `programs.ronema.settings.language` 
+
+      icons = ./icons; # A direction containing the icons for ronema. The directory must be similar in names and formats to `src/icons`
+
+      settings = {
+        ascii_out = false;
+        selection_prefix = "-";
+        y_axis = 0;
+      };
+    };
+  }
+  ```
+
+  #### Module Options
+
+
+  ##### [`options.programs.ronema.enable`](#L19)
+
+  Rofi NetworkManager applet
+
+  **Type:** `boolean`
+
+  **Default:** `false`
+
+  **Example:** `true`
+
+  ##### [`options.programs.ronema.package`](#L21)
+
+  The ronema package to use.
+
+  **Type:** `types.package`
+
+  **Default:** `package`
+
+  ##### [`options.programs.ronema.theme`](#L27)
+
+  Define the theme using rofi rasi. See https://nix-community.github.io/home-manager/options.xhtml#opt-programs.rofi.theme
+
+  **Type:** `rofiHelpers.themeType`
+
+  **Default:** `null`
+
+  ##### [`options.programs.ronema.languages`](#L33)
+
+
+  The path to a directory containing languages file for ronema.
+
+  The directory should contain at least the language defined in `programs.ronema.settings.language`
+
+  See: https://github.com/P3rf/rofi-network-manager/blob/master/src/languages/lang_file.example to learn how to make language files for ronema.
+
+
+  **Type:** `types.path`
+
+  **Default:** `"${package}/languages"`
+
+  ##### [`options.programs.ronema.icons`](#L45)
+
+
+  The path to a directory containing icons for ronema.
+
+  The directory must contain the following icons in the same names and formats:
+  - `alert.svg`
+  - `change.svg`
+  - `restart.svg`
+  - `scanning.svg`
+  - `vpn.svg`
+  - `wait.svg`
+  - `wifi-off.svg`
+  - `wifi-on.svg`
+  - `wired-off.svg`
+  - `wired-on.svg`
+
+
+  **Type:** `types.path`
+
+  **Default:** `"${package}/icons"`
+
+  ##### [`options.programs.ronema.settings.location`](#L66)
+
+
+  Location:
+  +-----------+
+  | 1 | 2 | 3 |
+  | 8 | 0 | 4 |
+  | 7 | 6 | 5 |
+  +-----------+
+  The grid represents the screen with the numbers indicating the location of the window.
+  If you want the window to be in the upper right corner, set location to 3.
+
+
+  **Type:** `locationType`
+
+  **Default:** `0`
+
+  ##### [`options.programs.ronema.settings.qrcode_location`](#L81)
+
+
+  This sets the anchor point for the window displaying the QR code.
+
+
+  **Type:** `locationType`
+
+  **Default:** `cfg.settings.location`
+
+  ##### [`options.programs.ronema.settings.x_axis`](#L89)
+
+  This sets the distance of the window from the edge of the
+  screen on the X axis.
+
+  **Type:** `types.int`
+
+  **Default:** `0`
+
+  ##### [`options.programs.ronema.settings.y_axis`](#L96)
+
+  This sets the distance of the window from the edge of the
+  screen on the Y axis.
+
+  **Type:** `types.int`
+
+  **Default:** `0`
+
+  ##### [`options.programs.ronema.settings.notifications`](#L103)
+
+  Use notifications or not.
+
+  **Type:** `types.bool`
+
+  **Default:** `false`
+
+  ##### [`options.programs.ronema.settings.notifications_icons`](#L109)
+
+  Use notifications icons or not.
+
+  **Type:** `types.bool`
+
+  **Default:** `false`
+
+  ##### [`options.programs.ronema.settings.qrcode_dir`](#L115)
+
+  Location of QRCode WiFi image.
+
+  **Type:** `types.nonEmptyStr`
+
+  **Default:** `"/tmp/"`
+
+  ##### [`options.programs.ronema.settings.width_fix_main`](#L121)
+
+
+  WIDTH_FIX_MAIN/WIDTH_FIX_STATUS
+  These values can be adjusted if the text doesn't fit or
+  if there is too much space at the end when you launch the script.
+  It will depend on the font type and size.
+
+
+  **Type:** `types.int`
+
+  **Default:** `1`
+
+  ##### [`options.programs.ronema.settings.width_fix_status`](#L132)
+
+
+  WIDTH_FIX_MAIN/WIDTH_FIX_STATUS
+  These values can be adjusted if the text doesn't fit or
+  if there is too much space at the end when you launch the script.
+  It will depend on the font type and size.
+
+
+  **Type:** `types.int`
+
+  **Default:** `10`
+
+  ##### [`options.programs.ronema.settings.ascii_out`](#L143)
+
+
+  Set it to true, if the script outputs the signal strength with asterisks
+  and you want bars.
+
+
+  **Type:** `types.bool`
+
+  **Default:** `false`
+
+  ##### [`options.programs.ronema.settings.change_bars`](#L152)
+
+
+  Set it to true if you want to use custom icons
+  for the signal strength instead of the default ones.
+
+
+  **Type:** `types.bool`
+
+  **Default:** `false`
+
+  ##### [`options.programs.ronema.settings.theme`](#L167)
+
+
+  The theme name for ronema.
+
+  This option is automatically set when you defined your own theme with `programs.rofi.applets.ronema`.
+  If you change it, your defined theme will not be applied.
+
+
+  **Type:** `types.nonEmptyStr`
+
+  **Default:**
+
+  ```nix
+  if cfg.theme != null
+  then generatedThemeName
+  else "ronema.rasi"
+  ```
+
+  ##### [`options.programs.ronema.settings.selection_prefix`](#L181)
+
+  The selection prefix.
+
+  **Type:** `types.nonEmptyStr`
+
+  **Default:** `"~"`
+
+  ##### [`options.programs.ronema.settings.language`](#L187)
+
+  The language file to use.
+
+  **Type:** `types.nonEmptyStr`
+
+  **Default:** `"english"`
+
+  ---
+  *Generated with [nix-options-doc](https://github.com/Thunderbottom/nix-options-doc)*
+  </details>
+
 ### Language Localization
 
-To localize Rofi-NetWork-manager to your preferred language:
+To localize ronema to your preferred language:
 
 1. **Create a New Language File**: Duplicate `lang_file.example` and rename it to match your language (e.g., `french.lang`).
 
@@ -127,6 +374,8 @@ cd rofi-network-manager
 ```
 
 ### Installing, Uninstalling, and Updating ronema
+
+#### With setup.sh
 
 To install ronema, run the following command:
 
@@ -152,6 +401,50 @@ To update ronema, run:
 The `--override_conf` flag is optional. If provided, it will override the existing configuration file during the update process.
 
 Configuration files will be located at `~/.config/ronema`.
+
+#### With Nix
+
+You can install ronema by directly referencing the flake in your configuration:
+
+```nix
+inputs = {
+  # ---Snip---
+  ronema = {
+    url = "gitlab:P3rf/rofi-network-manager";
+    # Optional, by default this flake follows nixpkgs-unstable.
+    inputs.nixpkgs.follows = "nixpkgs";
+  };
+  # ---Snip---
+}
+```
+
+This flake provides an overlay for Nixpkgs, a package and a Home-Manager module.
+They are respectively found in the flake as `inputs.ronema.overlays.default`, `inputs.ronema.packages.${system}.default` (Where `${system}` is either `x86_64-linux` or `aarch64-linux`) and `inputs.ronema.homeManagerModules.default`.
+
+Here is a simple example on how to install both the overlay and the module in
+your Home-Manager configuration:
+
+```nix
+outputs = inputs@{ ronema, ...}: {
+  # replace 'joes-desktop' with your hostname here.
+  nixosConfigurations.joes-desktop = home-manager.lib.homeManagerConfiguration {
+    system = "x86_64-linux";
+    modules = [
+      ronema.homeManagerModules.default
+      # Add your own modules here
+
+      # Example to add the overlay to Nixpkgs:
+      {
+        nixpkgs = {
+          overlays = [
+            ronema.overlays.default
+          ];
+        };
+      }
+    ];
+  };
+};
+```
 
 ### Themes
 
@@ -211,11 +504,11 @@ label-disconnected ="󰌺"
 ```
 </details>
 
-### ToDo
+### To-Do
 
 - [x] Fix notifications
 - [x] Add notifications icons
-- [x] Support for multiple wifi devices
+- [x] Support for multiple Wi-Fi devices
 - [ ] Add Hotspot support
-- [x] Share wifi password with qrcode inside rofi
+- [x] Share Wi-Fi password with qr code inside Rofi
 - [x] Find a way to manage duplicate Access Points

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,60 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1751413152,
+        "narHash": "sha256-Tyw1RjYEsp5scoigs1384gIg6e0GoBVjms4aXFfRssQ=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "77826244401ea9de6e3bac47c2db46005e1f30b5",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-parts",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1752620740,
+        "narHash": "sha256-f3pO+9lg66mV7IMmmIqG4PL3223TYMlnlw+pnpelbss=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "32a4e87942101f1c9f9865e04dc3ddb175f5f32e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1751159883,
+        "narHash": "sha256-urW/Ylk9FIfvXfliA1ywh75yszAbiTEVgpPeinFyVZo=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "14a40a1d7fb9afa4739275ac642ed7301a9ba1ab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1751413152,
-        "narHash": "sha256-Tyw1RjYEsp5scoigs1384gIg6e0GoBVjms4aXFfRssQ=",
+        "lastModified": 1763759067,
+        "narHash": "sha256-LlLt2Jo/gMNYAwOgdRQBrsRoOz7BPRkzvNaI/fzXi2Q=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "77826244401ea9de6e3bac47c2db46005e1f30b5",
+        "rev": "2cccadc7357c0ba201788ae99c4dfa90728ef5e0",
         "type": "github"
       },
       "original": {
@@ -19,27 +19,27 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1752620740,
-        "narHash": "sha256-f3pO+9lg66mV7IMmmIqG4PL3223TYMlnlw+pnpelbss=",
+        "lastModified": 1764173365,
+        "narHash": "sha256-JaNFPy3nywPNxSDpEgFFqvngQww5Igb6twG4NhMo8oc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "32a4e87942101f1c9f9865e04dc3ddb175f5f32e",
+        "rev": "2fecba9952096ba043c16b9ef40b92851ff3e5d9",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.05",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1751159883,
-        "narHash": "sha256-urW/Ylk9FIfvXfliA1ywh75yszAbiTEVgpPeinFyVZo=",
+        "lastModified": 1761765539,
+        "narHash": "sha256-b0yj6kfvO8ApcSE+QmA6mUfu8IYG6/uU28OFn4PaC8M=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "14a40a1d7fb9afa4739275ac642ed7301a9ba1ab",
+        "rev": "719359f4562934ae99f5443f20aa06c2ffff91fc",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -54,10 +54,10 @@
           };
         };
 
-        overlays.default = {pkgs, ...}: let
-          packages = withSystem pkgs.stdenv.hostPlatform.system ({config, ...}: config.packages);
+        overlays.default = {...}: let
+          packages = pkgs': withSystem pkgs'.stdenv.hostPlatform.system ({config, ...}: config.packages);
         in
-          final: prev: {ronema = packages.ronema;};
+          final: prev: {ronema = (packages prev).ronema;};
       };
     });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -54,10 +54,9 @@
           };
         };
 
-        overlays.default = {...}: let
-          packages = pkgs': withSystem pkgs'.stdenv.hostPlatform.system ({config, ...}: config.packages);
-        in
-          final: prev: {ronema = (packages prev).ronema;};
+        overlays.default = final: prev: let
+          packages = withSystem prev.stdenv.hostPlatform.system ({config, ...}: config.packages);
+        in {ronema = packages.ronema;};
       };
     });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -46,7 +46,7 @@
           };
 
           ronema = {pkgs, ...}: let
-            hm-module = import ./ronema/hm-module.nix {
+            hm-module = import ./nix/hm-module.nix {
               package = withSystem pkgs.stdenv.hostPlatform.system ({config, ...}: config.packages.ronema);
             };
           in {

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,63 @@
+{
+  description = "A flake for Ronema and its module.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+  };
+
+  outputs = inputs @ {
+    self,
+    flake-parts,
+    ...
+  }: let
+    version = self.rev or "git";
+  in
+    flake-parts.lib.mkFlake {inherit inputs;} ({withSystem, ...}: {
+      systems = ["x86_64-linux" "aarch64-linux"];
+
+      perSystem = {pkgs, ...}: {
+        devShells = {
+          default = pkgs.mkShell {
+            nativeBuildInputs = with pkgs; [
+              networkmanager
+              libnotify
+              networkmanagerapplet
+              qrencode
+            ];
+          };
+        };
+
+        packages = rec {
+          default = ronema;
+
+          ronema = pkgs.callPackage ./nix {
+            version = version;
+            src = ./.;
+          };
+        };
+      };
+
+      flake = {
+        homeManagerModules = rec {
+          default = {...}: {
+            imports = [
+              ronema
+            ];
+          };
+
+          ronema = {pkgs, ...}: let
+            hm-module = import ./ronema/hm-module.nix {
+              package = withSystem pkgs.stdenv.hostPlatform.system ({config, ...}: config.packages.ronema);
+            };
+          in {
+            imports = [hm-module];
+          };
+        };
+
+        overlays.default = {pkgs, ...}: let
+          packages = withSystem pkgs.stdenv.hostPlatform.system ({config, ...}: config.packages);
+        in
+          final: prev: {ronema = packages.ronema;};
+      };
+    });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "A flake for Ronema and its module.";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
   };
 
   outputs = inputs @ {

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,60 @@
+{
+  stdenvNoCC,
+  version ? "git",
+  src,
+  rofi,
+  rofi-wayland,
+  makeWrapper,
+  libnotify,
+  qrencode,
+  networkmanager,
+  networkmanagerapplet,
+  bash,
+  lib,
+  useWayland ? true,
+}: let
+  paths =
+    [
+      libnotify
+      qrencode
+      networkmanagerapplet
+      networkmanager
+    ]
+    ++ (
+      if useWayland
+      then [rofi-wayland]
+      else [rofi]
+    );
+  wrapperPath = lib.makeBinPath paths;
+in
+  stdenvNoCC.mkDerivation rec {
+    pname = "ronema";
+
+    inherit version src useWayland;
+
+    buildInputs = [
+      bash
+    ];
+
+    installPhase = ''
+      mkdir -p $out
+      mkdir -p $out/bin
+      cp -r -t $out src/themes src/languages src/icons src/ronema.conf
+      cp src/ronema $out/bin
+    '';
+
+    nativeBuildInputs = [
+      makeWrapper
+    ];
+
+    postFixup = ''
+      # Ensure all dependencies are in PATH
+        wrapProgram $out/bin/${pname} \
+          --prefix PATH : "${wrapperPath}"
+    '';
+
+    dontUseCmakeBuild = true;
+    dontUseCmakeConfigure = true;
+
+    meta.mainProgram = pname;
+  }

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -3,7 +3,6 @@
   version ? "git",
   src,
   rofi,
-  rofi-wayland,
   makeWrapper,
   libnotify,
   qrencode,
@@ -11,26 +10,20 @@
   networkmanagerapplet,
   bash,
   lib,
-  useWayland ? true,
 }: let
-  paths =
-    [
-      libnotify
-      qrencode
-      networkmanagerapplet
-      networkmanager
-    ]
-    ++ (
-      if useWayland
-      then [rofi-wayland]
-      else [rofi]
-    );
+  paths = [
+    libnotify
+    qrencode
+    networkmanagerapplet
+    networkmanager
+    rofi
+  ];
   wrapperPath = lib.makeBinPath paths;
 in
   stdenvNoCC.mkDerivation rec {
     pname = "ronema";
 
-    inherit version src useWayland;
+    inherit version src;
 
     buildInputs = [
       bash

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -1,0 +1,201 @@
+{package}: {
+  config,
+  lib,
+  ...
+}: let
+  inherit (lib) mkIf mkOption mkEnableOption types optionalString;
+  cfg = config.programs.rofi.applets.ronema;
+  rofiHelpers = import ../utils {inherit lib;};
+  mkSignalStrength = default:
+    mkOption {
+      inherit default;
+      type = types.str;
+      description = "Custom signal strength indicators.";
+    };
+  locationType = types.enum [0 1 2 3 4 5 6 7 8];
+  generatedThemeName = "hm-theme.rasi";
+in {
+  options.programs.rofi.applets.ronema = {
+    enable = mkEnableOption "Rofi NetworkManager applet";
+
+    package = mkOption {
+      type = types.package;
+      default = package;
+      description = "The ronema package to use.";
+    };
+
+    theme = mkOption {
+      type = rofiHelpers.themeType;
+      default = null;
+      description = "Define the theme config of the applet";
+    };
+
+    languages = mkOption {
+      type = types.path;
+      default = "${package}/languages";
+      description = ''
+        The path to a directory containing languages file for ronema.
+
+        The directory should contain at least the language defined in `programs.rofi.applets.ronema.settings.language`
+
+        See: https://github.com/P3rf/rofi-network-manager/blob/master/src/languages/lang_file.example to learn how to make language files for ronema.
+      '';
+    };
+
+    icons = mkOption {
+      type = types.path;
+      default = "${package}/icons";
+      description = ''
+        The path to a directory containing icons for ronema.
+
+        The directory should contain the following icons in the same names and formats:
+        - `alert.svg`
+        - `change.svg`
+        - `restart.svg`
+        - `scanning.svg`
+        - `vpn.svg`
+        - `wait.svg`
+        - `wifi-off.svg`
+        - `wifi-on.svg`
+        - `wired-off.svg`
+        - `wired-on.svg`
+      '';
+    };
+
+    settings = {
+      location = mkOption {
+        type = locationType;
+        default = 0;
+        description = ''
+          Location:
+          +---------- +
+          | 1 | 2 | 3 |
+          | 8 | 0 | 4 |
+          | 7 | 6 | 5 |
+          +-----------+
+          The grid represents the screen with the numbers indicating the location of the window.
+          If you want the window to be in the upper right corner, set location to 3.
+        '';
+      };
+
+      qrcode_location = mkOption {
+        type = locationType;
+        default = cfg.settings.location;
+        description = ''
+          This sets the anchor point for the window displaying the QR code.
+        '';
+      };
+
+      x_axis = mkOption {
+        type = types.int;
+        default = 0;
+        description = "This sets the distance of the window from the edge of the
+        screen on the X axis.";
+      };
+
+      y_axis = mkOption {
+        type = types.int;
+        default = 0;
+        description = "This sets the distance of the window from the edge of the
+        screen on the Y axis.";
+      };
+
+      notifications = mkOption {
+        type = types.enum ["true" "false"];
+        default = "false";
+        description = "Use notifications or not.";
+      };
+
+      qrcode_dir = mkOption {
+        type = types.nonEmptyStr;
+        default = "/tmp/";
+        description = "Location of QRCode WiFi image.";
+      };
+
+      width_fix_main = mkOption {
+        type = types.int;
+        default = 1;
+        description = ''
+          WIDTH_FIX_MAIN/WIDTH_FIX_STATUS
+          These values can be adjusted if the text doesn't fit or
+          if there is too much space at the end when you launch the script.
+          It will depend on the font type and size.
+        '';
+      };
+
+      width_fix_status = mkOption {
+        type = types.int;
+        default = 10;
+        description = ''
+          WIDTH_FIX_MAIN/WIDTH_FIX_STATUS
+          These values can be adjusted if the text doesn't fit or
+          if there is too much space at the end when you launch the script.
+          It will depend on the font type and size.
+        '';
+      };
+
+      ascii_out = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Set it to true, if the script outputs the signal strength with asterisks
+          and you want bars.
+        '';
+      };
+
+      change_bars = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Set it to true if you want to use custom icons
+          for the signal strength instead of the default ones.
+        '';
+      };
+
+      signal_strength_0 = mkSignalStrength "0";
+      signal_strength_1 = mkSignalStrength "1";
+      signal_strength_2 = mkSignalStrength "12";
+      signal_strength_3 = mkSignalStrength "123";
+      signal_strength_4 = mkSignalStrength "1234";
+
+      theme = mkOption {
+        type = types.nonEmptyStr;
+        default =
+          if cfg.theme != null
+          then generatedThemeName
+          else "ronema.rasi";
+        description = ''
+          The theme name for ronema.
+
+          This option is automatically set when you defined your own theme with `programs.rofi.applets.ronema`.
+          If you change it, your defined theme will not be applied.
+        '';
+      };
+
+      selection_prefix = mkOption {
+        type = types.nonEmptyStr;
+        default = "~";
+        description = "The selection prefix.";
+      };
+
+      language = mkOption {
+        type = types.nonEmptyStr;
+        default = "english";
+        description = "The language file to use.";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [cfg.package];
+
+    xdg.configFile = {
+      "ronema/themes/${generatedThemeName}".text =
+        optionalString (cfg.theme != null)
+        (rofiHelpers.toRasi cfg.theme);
+      "ronema/ronema.conf".text = rofiHelpers.toConf cfg.settings;
+      "ronema/icons".source = cfg.icons;
+      "ronema/languages".source = cfg.languages;
+    };
+  };
+}

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -3,9 +3,9 @@
   lib,
   ...
 }: let
-  inherit (lib) mkIf mkOption mkEnableOption types optionalString;
+  inherit (lib) mkIf mkOption mkEnableOption types;
   cfg = config.programs.ronema;
-  rofiHelpers = import ../utils {inherit lib;};
+  rofiHelpers = import ./utils.nix {inherit lib;};
   mkSignalStrength = default:
     mkOption {
       inherit default;

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -190,9 +190,7 @@ in {
     home.packages = [cfg.package];
 
     xdg.configFile = {
-      "ronema/themes/${generatedThemeName}".text =
-        optionalString (cfg.theme != null)
-        (rofiHelpers.toRasi cfg.theme);
+      "ronema/themes/${generatedThemeName}".text = mkIf (cfg.theme != null) (rofiHelpers.toRasi cfg.theme);
       "ronema/ronema.conf".text = rofiHelpers.toConf cfg.settings;
       "ronema/icons".source = cfg.icons;
       "ronema/languages".source = cfg.languages;

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -27,7 +27,7 @@ in {
     theme = mkOption {
       type = rofiHelpers.themeType;
       default = null;
-      description = "Define the theme config of the applet";
+      description = "Define the theme using rofi rasi. See https://nix-community.github.io/home-manager/options.xhtml#opt-programs.rofi.theme";
     };
 
     languages = mkOption {
@@ -36,7 +36,7 @@ in {
       description = ''
         The path to a directory containing languages file for ronema.
 
-        The directory should contain at least the language defined in `programs.rofi.applets.ronema.settings.language`
+        The directory should contain at least the language defined in `programs.ronema.settings.language`
 
         See: https://github.com/P3rf/rofi-network-manager/blob/master/src/languages/lang_file.example to learn how to make language files for ronema.
       '';
@@ -48,7 +48,7 @@ in {
       description = ''
         The path to a directory containing icons for ronema.
 
-        The directory should contain the following icons in the same names and formats:
+        The directory must contain the following icons in the same names and formats:
         - `alert.svg`
         - `change.svg`
         - `restart.svg`
@@ -68,7 +68,7 @@ in {
         default = 0;
         description = ''
           Location:
-          +---------- +
+          +-----------+
           | 1 | 2 | 3 |
           | 8 | 0 | 4 |
           | 7 | 6 | 5 |
@@ -101,9 +101,15 @@ in {
       };
 
       notifications = mkOption {
-        type = types.enum ["true" "false"];
-        default = "false";
+        type = types.bool;
+        default = false;
         description = "Use notifications or not.";
+      };
+
+      notifications_icons = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Use notifications icons or not.";
       };
 
       qrcode_dir = mkOption {

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -190,7 +190,9 @@ in {
     home.packages = [cfg.package];
 
     xdg.configFile = {
-      "ronema/themes/${generatedThemeName}".text = mkIf (cfg.theme != null) (rofiHelpers.toRasi cfg.theme);
+      "ronema/themes/${generatedThemeName}" = mkIf (cfg.theme != null) {
+        text = rofiHelpers.toRasi cfg.theme;
+      };
       "ronema/ronema.conf".text = rofiHelpers.toConf cfg.settings;
       "ronema/icons".source = cfg.icons;
       "ronema/languages".source = cfg.languages;

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -4,7 +4,7 @@
   ...
 }: let
   inherit (lib) mkIf mkOption mkEnableOption types optionalString;
-  cfg = config.programs.rofi.applets.ronema;
+  cfg = config.programs.ronema;
   rofiHelpers = import ../utils {inherit lib;};
   mkSignalStrength = default:
     mkOption {
@@ -15,7 +15,7 @@
   locationType = types.enum [0 1 2 3 4 5 6 7 8];
   generatedThemeName = "hm-theme.rasi";
 in {
-  options.programs.rofi.applets.ronema = {
+  options.programs.ronema = {
     enable = mkEnableOption "Rofi NetworkManager applet";
 
     package = mkOption {

--- a/nix/utils.nix
+++ b/nix/utils.nix
@@ -1,0 +1,132 @@
+{lib}:
+/*
+  Most of these Rofi utils come from:
+* https://github.com/nix-community/home-manager/blob/master/modules/programs/rofi.nix
+*/
+let
+  inherit
+    (lib)
+    isBool
+    isInt
+    isString
+    isList
+    isAttrs
+    generators
+    filterAttrs
+    concatStringsSep
+    concatMap
+    types
+    mapAttrsToList
+    mkOption
+    toUpper
+    isPath
+    ;
+in rec {
+  mkValueString = value:
+    if isBool value
+    then
+      if value
+      then "true"
+      else "false"
+    else if isInt value
+    then toString value
+    else if (value._type or "") == "literal"
+    then value.value
+    else if isString value
+    then ''"${value}"''
+    else if isList value
+    then "[ ${concatStringsSep "," (map mkValueString value)} ]"
+    else abort "Unhandled value type ${builtins.typeOf value}";
+
+  mkKeyValue = {
+    sep ? ": ",
+    end ? ";",
+  }: name: value: "${name}${sep}${mkValueString value}${end}";
+
+  mkRasiSection = name: value:
+    if isAttrs value
+    then let
+      toRasiKeyValue = generators.toKeyValue {mkKeyValue = mkKeyValue {};};
+      # Remove null values so the resulting config does not have empty lines
+      configStr = toRasiKeyValue (filterAttrs (_: v: v != null) value);
+    in ''
+      ${name} {
+      ${configStr}}
+    ''
+    else
+      (mkKeyValue {
+          sep = " ";
+          end = "";
+        }
+        name
+        value)
+      + "\n";
+
+  toRasi = attrs:
+    concatStringsSep "\n" (concatMap (mapAttrsToList mkRasiSection) [
+      (filterAttrs (n: _: n == "@theme") attrs)
+      (filterAttrs (n: _: n == "@import") attrs)
+      (removeAttrs attrs ["@theme" "@import"])
+    ]);
+
+  # Either a `section { foo: "bar"; }` or a `@import/@theme "some-text"`
+  configType = with types; (
+    either (
+      attrsOf (
+        either primitive (listOf primitive)
+      )
+    )
+    str
+  );
+
+  themeType = with types; nullOr (attrsOf configType);
+
+  rasiLiteral =
+    types.submodule {
+      options = {
+        _type = mkOption {
+          type = types.enum ["literal"];
+          internal = true;
+        };
+
+        value = mkOption {
+          type = types.str;
+          internal = true;
+        };
+      };
+    }
+    // {
+      description = "Rasi literal string";
+    };
+
+  toConf = config:
+    concatStringsSep "\n" (
+      mapAttrsToList
+      (
+        name: value: let
+          valueToWrite =
+            if isBool value
+            then
+              if value
+              then "true"
+              else "false"
+            else if isInt value
+            then toString value
+            else if (isString value || isPath value)
+            then ''"${value}"''
+            else if isAttrs value
+            then
+              "("
+              + concatStringsSep " " (mapAttrsToList (name: item: ''["${name}"]="${toString item}"'') value)
+              + ")"
+            else if isList value
+            then
+              "("
+              + concatStringsSep " " (builtins.map (item: ''"${item}"'') value)
+              + ")"
+            else abort "Unhandled value type ${builtins.typeOf value}";
+        in ''${toUpper name}=${valueToWrite}''
+      )
+      config
+    );
+}

--- a/nix/utils.nix
+++ b/nix/utils.nix
@@ -79,6 +79,8 @@ in rec {
     str
   );
 
+  primitive = with types; (oneOf [str int bool rasiLiteral]);
+
   themeType = with types; nullOr (attrsOf configType);
 
   rasiLiteral =

--- a/src/ronema
+++ b/src/ronema
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 WIRELESS_INTERFACES=($(nmcli device | awk '$2=="wifi" {print $1}'))
 WIRELESS_INTERFACES_PRODUCT=()
 WLAN_INT=0
@@ -7,10 +7,10 @@ WIRED_INTERFACES=($(nmcli device | awk '$2=="ethernet" {print $1}'))
 WIRED_INTERFACES_PRODUCT=()
 VPN_PATTERN='(wireguard|vpn)'
 function initialization() {
-	source "$DIR/ronema.conf" || source "${XDG_CONFIG_HOME:-$HOME/.config}/ronema/ronema.conf" || exit
-	source "$DIR/languages/${LANGUAGE}.lang" || source "${XDG_CONFIG_HOME:-$HOME/.config}/ronema/languages/${LANGUAGE}.lang" || exit
-	{ [[ -f "$DIR/themes/${THEME}" ]] && RASI_DIR="$DIR/themes/${THEME}"; } || { [[ -f "${XDG_CONFIG_HOME:-$HOME/.config}/ronema/themes/${THEME}" ]] && RASI_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/ronema/themes/${THEME}"; } || exit
-	{ [[ -d "$DIR/icons" ]] && ICON_DIR="$DIR/icons" ; } || { [[ -d "${XDG_CONFIG_HOME:-$HOME/.config}/ronema/icons" ]] && ICON_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/ronema/icons" ; } || exit
+	{ [[ -f "${XDG_CONFIG_HOME:-$HOME/.config}/ronema/ronema.conf" ]] && source "${XDG_CONFIG_HOME:-$HOME/.config}/ronema/ronema.conf"; } || source "$DIR/ronema.conf" || exit
+	{ [[ -f "${XDG_CONFIG_HOME:-$HOME/.config}/ronema/languages/${LANGUAGE}.lang" ]] && source "${XDG_CONFIG_HOME:-$HOME/.config}/ronema/languages/${LANGUAGE}.lang"; } || source "$DIR/languages/${LANGUAGE}.lang" || exit
+	{ [[ -f "${XDG_CONFIG_HOME:-$HOME/.config}/ronema/themes/${THEME}" ]] && RASI_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/ronema/themes/${THEME}"; } || { [[ -f "$DIR/themes/${THEME}" ]] && RASI_DIR="$DIR/themes/${THEME}"; } || exit
+	 { [[ -d "${XDG_CONFIG_HOME:-$HOME/.config}/ronema/icons" ]] && ICON_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/ronema/icons" ; } || { [[ -d "$DIR/icons" ]] && ICON_DIR="$DIR/icons" ; } || exit
 	for i in "${WIRELESS_INTERFACES[@]}"; do WIRELESS_INTERFACES_PRODUCT+=("$(nmcli -f general.product device show "$i" | awk '{print $2}')"); done
 	for i in "${WIRED_INTERFACES[@]}"; do WIRED_INTERFACES_PRODUCT+=("$(nmcli -f general.product device show "$i" | awk '{print $2}')"); done
 	wireless_interface_state && ethernet_interface_state


### PR DESCRIPTION
This PR adds support for Nix by offering a flake with a package to build ronema, an overlay and Home-Manager module.

I also added a small fix to make ronema source its configuration first from `XDG_CONFIG_DIRS/ronema`, defaulting to the configuration on its root directory if none exists. This helps configuration through Home-Manager and avoids having to modify the package derivation every time we make a change in the configuration on the Nix side. This change should not impact people not using Nix.

I also updated the README to add instructions on how to install it with Nix and Home-Manager and the module documentation, trying to respect how you organized your README.

Finally, I offer my help in maintaining this flake, its module and documentation if this PR is merged.

I hope it is agreeable for you! 

This PR fixes #27 